### PR TITLE
Remove arrows if don't exists posts

### DIFF
--- a/public/class-floating-nextprev.php
+++ b/public/class-floating-nextprev.php
@@ -231,6 +231,8 @@ class Floating_NextPrev {
 			$next_title          = apply_filters( $this->get_settings_name() . '_next_title', __( 'Next', $slug ) );
 			$prev_post           = get_previous_post( $in_same_cat, $excluded_categories );
 			$next_post           = get_next_post( $in_same_cat, $excluded_categories );
+			$exists_next_post = ( get_the_ID() !== $next_post->ID && ! is_null( $next_post->ID ) )? true : false ;
+			$exists_prev_post = ( get_the_ID() !== $prev_post->ID && ! is_null( $prev_post->ID ))? true : false ;
 
 			include_once 'views/public.php';
 		}

--- a/public/views/public.php
+++ b/public/views/public.php
@@ -14,6 +14,7 @@ if ( ! defined( 'WPINC' ) ) die;
 ?>
 
 <div id="<?php echo $slug; ?>" class="style-<?php echo sanitize_text_field( $settings['model'] ); ?>">
+	<?php if ( $exists_prev_post ) : ?>
 	<div class="<?php echo $slug; ?>-prev <?php echo $slug; ?>-nav">
 		<a rel="prev" href="<?php echo get_permalink( $prev_post->ID ); ?>">
 			<div class="<?php echo $slug; ?>-arrow-left"></div>
@@ -24,6 +25,8 @@ if ( ! defined( 'WPINC' ) ) die;
 			</div>
 		</a>
 	</div>
+	<?php endif; ?>
+	<?php if ( $exists_next_post ) : ?>
 	<div class="<?php echo $slug; ?>-next <?php echo $slug; ?>-nav">
 		<a rel="next" href="<?php echo get_permalink( $next_post->ID ); ?>">
 			<div class="<?php echo $slug; ?>-arrow-right"></div>
@@ -34,4 +37,5 @@ if ( ! defined( 'WPINC' ) ) die;
 			</div>
 		</a>
 	</div>
+	<?php endif; ?>
 </div>


### PR DESCRIPTION
When there aren't previous or next post, the link always goes to
the same post, it can confuse the user. In order to avoid this
behaviour, the plugin check if exists a post, otherwise don't show
the link.
